### PR TITLE
CONDEC-854: Refactor tests for creation of decision knowledge

### DIFF
--- a/test/helpers.js
+++ b/test/helpers.js
@@ -111,7 +111,6 @@ const createJiraIssue = async (
       },
     },
   });
-  console.info(`Created issue: ${createdIssue.key}`);
   return createdIssue;
 };
 
@@ -143,7 +142,6 @@ const setSentenceIrrelevant = async (sentenceId) => {
  * issue persistence strategy
  */
 const setUpJira = async (useIssueStrategy = false) => {
-  console.info('Setting up jira...');
   try {
     // delete existing project with the configured key (if it exists)
     const allProjects = await jira.listProjects();
@@ -165,8 +163,6 @@ const setUpJira = async (useIssueStrategy = false) => {
     await activateConDec();
     // explicitly set whether to use the issue persistence strategy or not
     await setIssueStrategy(useIssueStrategy);
-
-    console.info('Successfully set up Jira!');
   } catch (err) {
     console.error(err);
     throw err;

--- a/test/test_CreateDecisionKnowledge.js
+++ b/test/test_CreateDecisionKnowledge.js
@@ -10,7 +10,7 @@ const {
 chai.use(require('chai-like'));
 chai.use(require('chai-things'));
 
-describe.only('TCS: CONDEC-168', () => {
+describe('TCS: CONDEC-168', () => {
   // reset Jira project for every test case, to ensure no interference
   beforeEach(async () => {
     // explicitly use issue persistence strategy here

--- a/test/test_CreateDecisionKnowledge.js
+++ b/test/test_CreateDecisionKnowledge.js
@@ -4,21 +4,20 @@ const {
   setUpJira,
   createJiraIssue,
   jira,
-  getKnowledgeElements,
   createDecisionKnowledgeElement,
 } = require('./helpers.js');
 
 chai.use(require('chai-like'));
 chai.use(require('chai-things'));
 
-describe('TCS: CONDEC-168', () => {
+describe.only('TCS: CONDEC-168', () => {
   // reset Jira project for every test case, to ensure no interference
   beforeEach(async () => {
     // explicitly use issue persistence strategy here
     await setUpJira(true);
   });
   xit(
-    // This will be tested elsewhere
+    // This is out of scope of test plan v1
     '(R1) If the decision knowledge element is created within an existing knowledge element ' +
       '(Jira issue or code file), a link is created between an existing knowledge' +
       ' element and the new element (CONDEC-291). '
@@ -86,7 +85,7 @@ describe('TCS: CONDEC-168', () => {
         'i'
       ); // by default this issue is unlinked
 
-      chai.expect(issue).to.have.prooperty('summary', 'Dummy issue for R5');
+      chai.expect(issue).to.have.property('summary', 'Dummy issue for R5');
       chai.expect(issue).to.have.property('status', 'unresolved');
       chai.expect(issue).to.have.property('type', 'Issue');
     }

--- a/test/test_CreateDecisionKnowledge.js
+++ b/test/test_CreateDecisionKnowledge.js
@@ -48,9 +48,12 @@ describe('TCS: CONDEC-168', () => {
   );
   it('(R3) A new alternative has the status "idea".', async () => {
     const issue = await createJiraIssue('Issue', 'Dummy issue for R3');
-    await jira.addComment(
+    await createDecisionKnowledgeElement(
+      'dummy alternative for R3',
+      'Alternative',
+      's',
       issue.id,
-      '{alternative}dummy alternative for R3{alternative}'
+      'i'
     );
     const knowledgeElements = await getKnowledgeElements();
     chai

--- a/test/test_CreateDecisionKnowledge.js
+++ b/test/test_CreateDecisionKnowledge.js
@@ -48,23 +48,21 @@ describe('TCS: CONDEC-168', () => {
   );
   it('(R3) A new alternative has the status "idea".', async () => {
     const issue = await createJiraIssue('Issue', 'Dummy issue for R3');
-    await createDecisionKnowledgeElement(
+    const alternative = await createDecisionKnowledgeElement(
       'dummy alternative for R3',
       'Alternative',
       's',
       issue.id,
       'i'
     );
-    const knowledgeElements = await getKnowledgeElements();
+
     chai
-      .expect(knowledgeElements)
-      .to.be.an('Array')
-      .that.contains.something.like({
-        summary: 'dummy alternative for R3',
-        status: 'idea',
-        type: 'Alternative',
-      });
+      .expect(alternative)
+      .to.have.property('summary', 'dummy alternative for R3');
+    chai.expect(alternative).to.have.property('status', 'idea');
+    chai.expect(alternative).to.have.property('type', 'Alternative');
   });
+
   it('(R4) A new decision has the status "decided".', async () => {
     const issue = await createJiraIssue('Issue', 'Dummy issue for R4');
     await jira.addComment(

--- a/test/test_CreateDecisionKnowledge.js
+++ b/test/test_CreateDecisionKnowledge.js
@@ -1,13 +1,10 @@
-const axios = require('axios');
 const chai = require('chai');
 
-const JSONConfig = require('../config.json');
 const {
   setUpJira,
   createJiraIssue,
   jira,
   getKnowledgeElements,
-  localCredentialsObject,
   createDecisionKnowledgeElement,
 } = require('./helpers.js');
 

--- a/test/test_CreateDecisionKnowledge.js
+++ b/test/test_CreateDecisionKnowledge.js
@@ -80,18 +80,18 @@ describe('TCS: CONDEC-168', () => {
     '(R5) A new issue (=decision problem), i.e. an issue without linked decision has' +
       ' the status "unresolved".',
     async () => {
-      await createJiraIssue('Issue', 'Dummy issue for R5');
-      const knowledgeElements = await getKnowledgeElements();
-      chai
-        .expect(knowledgeElements)
-        .to.be.an('Array')
-        .that.contains.something.like({
-          summary: 'Dummy issue for R5',
-          status: 'unresolved',
-          type: 'Issue',
-        });
+      const issue = await createDecisionKnowledgeElement(
+        'Dummy issue for R5',
+        'Issue',
+        'i'
+      ); // by default this issue is unlinked
+
+      chai.expect(issue).to.have.prooperty('summary', 'Dummy issue for R5');
+      chai.expect(issue).to.have.property('status', 'unresolved');
+      chai.expect(issue).to.have.property('type', 'Issue');
     }
   );
+
   xit(
     // This will be tested elsewhere
     '(R6) A Jira issue (i.e. a decision knowledge element documented as an entire Jira issue) can' +

--- a/test/test_CreateDecisionKnowledge.js
+++ b/test/test_CreateDecisionKnowledge.js
@@ -65,19 +65,16 @@ describe('TCS: CONDEC-168', () => {
 
   it('(R4) A new decision has the status "decided".', async () => {
     const issue = await createJiraIssue('Issue', 'Dummy issue for R4');
-    await jira.addComment(
+    const decision = await createDecisionKnowledgeElement(
+      'dummy decision for R4',
+      'Decision',
+      's',
       issue.id,
-      '{decision}dummy decision for R4{decision}'
+      'i'
     );
-    const knowledgeElements = await getKnowledgeElements();
-    chai
-      .expect(knowledgeElements)
-      .to.be.an('Array')
-      .that.contains.something.like({
-        summary: 'dummy decision for R4',
-        status: 'decided',
-        type: 'Decision',
-      });
+    chai.expect(decision).to.have.property('summary', 'dummy decision for R4');
+    chai.expect(decision).to.have.property('status', 'decided');
+    chai.expect(decision).to.have.property('type', 'Decision');
   });
   it(
     '(R5) A new issue (=decision problem), i.e. an issue without linked decision has' +

--- a/test/test_CreateDecisionKnowledge.js
+++ b/test/test_CreateDecisionKnowledge.js
@@ -8,6 +8,7 @@ const {
   jira,
   getKnowledgeElements,
   localCredentialsObject,
+  createDecisionKnowledgeElement,
 } = require('./helpers.js');
 
 chai.use(require('chai-like'));
@@ -31,17 +32,12 @@ describe('TCS: CONDEC-168', () => {
       ' knowledge element.',
     async () => {
       const task = await createJiraIssue('Task', 'Dummy task for R2');
-      await axios.post(
-        `${JSONConfig.fullUrl}/rest/condec/latest/knowledge` +
-          `/createDecisionKnowledgeElement.json?idOfExistingElement=${task.id}` +
-          `&documentationLocationOfExistingElement=i`,
-        {
-          type: 'Issue',
-          projectKey: JSONConfig.projectKey,
-          description: 'Dummy decision knowledge issue for R2',
-          documentationLocation: 's',
-        },
-        localCredentialsObject
+      await createDecisionKnowledgeElement(
+        'Dummy decision knowledge issue for R2',
+        'Issue',
+        's',
+        task.id,
+        'i'
       );
       const taskAfterUpdate = await jira.findIssue(task.key);
 
@@ -49,7 +45,7 @@ describe('TCS: CONDEC-168', () => {
         .expect(taskAfterUpdate.fields.comment.comments)
         .to.be.an('Array')
         .that.contains.something.like({
-          body: '{issue}\nDummy decision knowledge issue for R2{issue}',
+          body: '{issue}Dummy decision knowledge issue for R2\n{issue}',
         });
     }
   );


### PR DESCRIPTION
Refactor the tests for decision knowledge creation to make them more readable and not directly call axios. This helps future-proof them, and makes them more independent, since they no longer rely on the comment parsing from the ConDec plugin, but rather use the CreateDecisionKnowledge endpoint, which itself is used inside the plugin.

- Refactor test for (R2) to use helper function
- Remove unused imports
- Refactor (R3) to use createDecisionKnowledge helper
- Refactor (R3) further to be more concise
- Refactor test for (R4)
- Refactor test case for (R4)
- fix typo
- Remove console statements as they spam the test output
