### PR TITLE
Add default issue type name to config.json for multi-language support  

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ npm install
 
 ### Adding your local configuration to the repo
 
-You will need to copy the file `config-template.json` and name the copy `config.json`. In `config.json` you can change the settings to use a specific URL for Jira or a specific user.
+You will need to copy the file `config-template.json` and name the copy
+`config.json`. In `config.json` you can change the settings to use a specific
+URL for Jira or a specific user. If you are using Jira issue types with names in
+a language other than English, you can set the property "defaultIssueType" to an
+issue type name existing on your system. For German, a good value for this
+property is "Aufgabe", which corresponds to the type "Task", which is the
+standard task type for the default issue type scheme.
 **Do not push the `config.json` file!** It contains data local to your computer, which could be sensitive!
 
 ## Running the tests
@@ -25,7 +31,6 @@ Checklist:
 
 - [ ] (optional) run `atlas-clean` to clean the Jira database
 - [ ] Run Jira using `atlas-run`
-- [ ] Disable and then enable the ConDec plugin
 
 You are now ready to run the tests!
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,11 @@ npm install
 ### Adding your local configuration to the repo
 
 You will need to copy the file `config-template.json` and name the copy
-`config.json`. In `config.json` you can change the settings to use a specific
-URL for Jira or a specific user. If you are using Jira issue types with names in
-a language other than English, you can set the property "defaultIssueType" to an
-issue type name existing on your system. For German, a good value for this
-property is "Aufgabe", which corresponds to the type "Task", which is the
-standard task type for the default issue type scheme.
+`config.json`.
+
+* In `config.json` you can change the settings to use a specific URL for Jira or a specific user.
+* If you are using Jira issue types with names in a language other than English, you can set the property "defaultIssueType" to an issue type name existing on your system. For German, a good value for this property is "Aufgabe", which corresponds to the type "Task", which is the standard task type for the default issue type scheme.
+
 **Do not push the `config.json` file!** It contains data local to your computer, which could be sensitive!
 
 ## Running the tests

--- a/config-template.json
+++ b/config-template.json
@@ -4,5 +4,6 @@
   "fullUrl": "http://localhost:2990/jira",
   "localJiraUsername": "admin",
   "localJiraPassword": "admin",
-  "projectKey": "CDTEST"
+  "projectKey": "CDTEST",
+  "defaultIssueType": "Task"
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -107,7 +107,9 @@ const deleteDecisionKnowledgeElement = async (id, documentationLocation) => {
  * Creates a Jira issue with the project, user, and Jira instance configured in the `config.json`.
  * The user is used as the reporter of the issue.
  *
- * @param  {string} issueTypeName - must be a valid Jira issue type for the configured instance
+ * @param  {string} issueTypeName - can be overridden by the parameter
+ * "defaultIssueType" in the config.json. This is useful for users using Jira
+ * with a language other than English configured.
  * @param  {string} issueSummary
  * @param  {?string} issueDescription - optional - if not specified, the issue description will be empty
  *
@@ -121,7 +123,9 @@ const createJiraIssue = async (issueTypeName, issueSummary, issueDescription = '
       summary: issueSummary,
       description: issueDescription,
       issuetype: {
-        name: issueTypeName,
+        // Override the hardcoded issue type name in order to work on systems
+        // with different languages
+        name: issueTypeName === JSONConfig.defaultIssueType ? issueTypeName : JSONConfig.defaultIssueType,
       },
       reporter: {
         name: JSONConfig.localJiraUsername,

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -123,9 +123,7 @@ const createJiraIssue = async (issueTypeName, issueSummary, issueDescription = '
       summary: issueSummary,
       description: issueDescription,
       issuetype: {
-        // Override the hardcoded issue type name in order to work on systems
-        // with different languages
-        name: issueTypeName === JSONConfig.defaultIssueType ? issueTypeName : JSONConfig.defaultIssueType,
+        name: issueTypeName,
       },
       reporter: {
         name: JSONConfig.localJiraUsername,

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -107,9 +107,9 @@ const deleteDecisionKnowledgeElement = async (id, documentationLocation) => {
  * Creates a Jira issue with the project, user, and Jira instance configured in the `config.json`.
  * The user is used as the reporter of the issue.
  *
- * @param  {string} issueTypeName - can be overridden by the parameter
- * "defaultIssueType" in the config.json. This is useful for users using Jira
- * with a language other than English configured.
+ * @param  {string} issueTypeName - must be a valid Jira issue type for the
+ * configured instance. For the "Task" type (and its equivalents in other
+ * languages), the config.json parameter "defaultIssueType" should be used
  * @param  {string} issueSummary
  * @param  {?string} issueDescription - optional - if not specified, the issue description will be empty
  *

--- a/test/test_ChangeDecisionKnowledgeElement.js
+++ b/test/test_ChangeDecisionKnowledgeElement.js
@@ -9,6 +9,8 @@ const {
   getSpecificKnowledgeElement,
 } = require('./helpers.js');
 
+const { defaultIssueType } = require('../config.json');
+
 chai.use(require('chai-like'));
 chai.use(require('chai-things'));
 /**
@@ -32,7 +34,7 @@ describe('TCS: Test change decision knowledge element', () => {
    * Postcondition system: The alternative changed to a decision with status decided
    */
   it('should change the status to "decided" when an alternative is changed to a decision (R1)', async () => {
-    const jiraTask = await createJiraIssue('Task', 'Enable persistence of user data');
+    const jiraTask = await createJiraIssue(defaultIssueType, 'Enable persistence of user data');
 
     const issue = await createDecisionKnowledgeElement(
       'Which database should be used to store user data?',

--- a/test/test_CreateDecisionKnowledgeElement.js
+++ b/test/test_CreateDecisionKnowledgeElement.js
@@ -2,6 +2,8 @@ const chai = require('chai');
 
 const { setUpJira, createJiraIssue, jira, createDecisionKnowledgeElement } = require('./helpers.js');
 
+const { defaultIssueType } = require('../config.json');
+
 chai.use(require('chai-like'));
 chai.use(require('chai-things'));
 
@@ -28,7 +30,7 @@ describe('TCS: Test create decision knowledge element', () => {
    * Postcondition system: The Jira issue has a comment containing the added decision knowledge element
    */
   it('should create a new comment for an existing Jira issue when the documentation location "Jira issue text" is selected (R2)', async () => {
-    const task = await createJiraIssue('Task', 'Dummy task for R2');
+    const task = await createJiraIssue(defaultIssueType, 'Dummy task for R2');
 
     await createDecisionKnowledgeElement('Dummy decision knowledge issue for R2', 'Issue', 's', task.id, 'i');
 

--- a/test/test_DeleteKnowledgeElement.js
+++ b/test/test_DeleteKnowledgeElement.js
@@ -11,6 +11,7 @@ const {
   deleteDecisionKnowledgeElement,
 } = require('./helpers.js');
 
+const { defaultIssueType } = require('../config.json');
 // chai-like provides the 'like' function, which searches for an object's subset
 chai.use(require('chai-like'));
 // chai-things allows us to use 'something' syntax to access array elements without knowing their indices
@@ -76,7 +77,7 @@ describe('TCS: Test delete knowledge element', () => {
    */
   it('should remove knowledge elements from issue description and comments from the database when a Jira issue is deleted (R2)', async () => {
     const issue = await createJiraIssue(
-      'Task',
+      defaultIssueType,
       'Develop strategy for maximizing joy',
       '{issue}Which method of transportation to use?{issue}\n{alternative}Use a bicycle!{alternative}'
     );
@@ -106,7 +107,10 @@ describe('TCS: Test delete knowledge element', () => {
    * Postcondition system: The Jira issue is no longer stored as decision knowledge
    */
   it('should delete the knowledge element representing a Jira issue from the graph when the Jira issue is deleted (R3)', async () => {
-    const issue = await createJiraIssue('Task', 'Develop strategy for fast and cost-effective pizza delivery');
+    const issue = await createJiraIssue(
+      defaultIssueType,
+      'Develop strategy for fast and cost-effective pizza delivery'
+    );
     await jira.deleteIssue(issue.id);
 
     const knowledgeElements = await getKnowledgeElements();
@@ -132,7 +136,7 @@ describe('TCS: Test delete knowledge element', () => {
    */
   it('should delete all decision knowledge from the database that was in the body of a Jira issue comment when the comment is deleted (R4)', async () => {
     // Precondition: Jira issue exists with a comment containing decision knowledge
-    const createdIssue = await createJiraIssue('Task', 'Plan the tasks from June until October');
+    const createdIssue = await createJiraIssue(defaultIssueType, 'Plan the tasks from June until October');
     const addedComment = await jira.addComment(
       createdIssue.key,
       '{issue}Which language should we use to define tasks?{issue}'
@@ -161,7 +165,11 @@ describe('TCS: Test delete knowledge element', () => {
    */
 
   it('should delete a knowledge element from the database when it is removed from the description of a Jira issue (R5)', async () => {
-    const issue = await createJiraIssue('Task', 'Buy mugs for serving coffee', '(!) How large to make the mugs?');
+    const issue = await createJiraIssue(
+      defaultIssueType,
+      'Buy mugs for serving coffee',
+      '(!) How large to make the mugs?'
+    );
 
     await jira.updateIssue(issue.id, {
       update: { description: [{ set: 'foo' }] },
@@ -188,7 +196,7 @@ describe('TCS: Test delete knowledge element', () => {
    */
   it('should delete a knowledge element from the database when deletion is triggered in a view on the knowledge graph (R6)', async () => {
     // Precondition: Decision knowledge element exists
-    const jiraIssue = await createJiraIssue('Task', 'Order coffee from suppliers');
+    const jiraIssue = await createJiraIssue(defaultIssueType, 'Order coffee from suppliers');
     const knowledgeElement = await createDecisionKnowledgeElement(
       'Which suppliers should be contacted?',
       'Issue',
@@ -216,7 +224,7 @@ describe('TCS: Test delete knowledge element', () => {
    */
   it('should not remove knowledge element from comment when it is deleted via a view on the knowledge graph (R7)', async () => {
     // Precondition: Jira issue exists with decision knowledge in its description or comment
-    const jiraIssue = await createJiraIssue('Task', 'Set up eBay storefront for the Moo company');
+    const jiraIssue = await createJiraIssue(defaultIssueType, 'Set up eBay storefront for the Moo company');
     const knowledgeElement = await createDecisionKnowledgeElement(
       "Accept only currencies we don't have to pay fees for!",
       'Issue',

--- a/test/test_FilterKnowledgeGraph.js
+++ b/test/test_FilterKnowledgeGraph.js
@@ -7,6 +7,8 @@ const {
   createDecisionKnowledgeElement,
 } = require('./helpers');
 
+const { defaultIssueType } = require('../config.json');
+
 chai.use(require('chai-like'));
 chai.use(require('chai-things'));
 
@@ -34,7 +36,7 @@ describe('TCS: Test filter knowledge graph', () => {
     // Precondition: A Jira issue exists. Two decision knowledge elements are linked to the issue,
     // each having a different summary
 
-    const jiraTask = await createJiraIssue('Task', 'Create a contact form');
+    const jiraTask = await createJiraIssue(defaultIssueType, 'Create a contact form');
 
     const issue = await createDecisionKnowledgeElement(
       'How should the phone number be stored?',
@@ -68,7 +70,7 @@ describe('TCS: Test filter knowledge graph', () => {
    * Postcondition system: Nothing changed
    */
   it('should filter by knowledge type of knowledge elements (R1)', async () => {
-    const jiraTask = await createJiraIssue('Task', 'Create an about page');
+    const jiraTask = await createJiraIssue(defaultIssueType, 'Create an about page');
 
     const issue = await createDecisionKnowledgeElement(
       'Whose picture should be put on the  about page?',
@@ -113,7 +115,7 @@ describe('TCS: Test filter knowledge graph', () => {
    */
   it('should not show irrelevant text when using the default settings (R1)', async () => {
     // Precondition: A knowledge element exists, containing text not marked as decision knowledge
-    const jiraTask = await createJiraIssue('Task', 'Create order form');
+    const jiraTask = await createJiraIssue(defaultIssueType, 'Create order form');
 
     await jira.addComment(
       jiraTask.id,

--- a/test/test_ManuallyClassifyTextAsDecisionKnowledge.js
+++ b/test/test_ManuallyClassifyTextAsDecisionKnowledge.js
@@ -11,6 +11,8 @@ const {
   filterKnowledgeElements,
 } = require('./helpers.js');
 
+const { defaultIssueType } = require('../config.json');
+
 chai.use(require('chai-like'));
 chai.use(require('chai-things'));
 /**
@@ -46,7 +48,7 @@ describe('TCS: Test manually classify text as decision knowledge', () => {
       - {con} Reduces usability. {con}
      */
 
-    const jiraIssue = await createJiraIssue('Task', 'Create a blog page for the Moo company');
+    const jiraIssue = await createJiraIssue(defaultIssueType, 'Create a blog page for the Moo company');
     await jira.addComment(
       jiraIssue.id,
       '{issue}Which site generator should be used to make the blog?{issue}\n' +
@@ -114,7 +116,7 @@ describe('TCS: Test manually classify text as decision knowledge', () => {
     (-) - con
      */
 
-    const jiraIssue = await createJiraIssue('Task', 'Decide on the domain name for the blog');
+    const jiraIssue = await createJiraIssue(defaultIssueType, 'Decide on the domain name for the blog');
     await jira.addComment(
       jiraIssue.id,
       '(!) Which domain registrar should be used?\n' +
@@ -166,7 +168,7 @@ describe('TCS: Test manually classify text as decision knowledge', () => {
    *
    */
   it('should replace Jira icons with macro tags in Jira issue comments (R2)', async () => {
-    const issue = await createJiraIssue('Task', 'Enable website navigation');
+    const issue = await createJiraIssue(defaultIssueType, 'Enable website navigation');
 
     await jira.addComment(
       issue.id,
@@ -197,7 +199,7 @@ describe('TCS: Test manually classify text as decision knowledge', () => {
    *
    */
   it('should set knowledge type of parts of a sentence not annotated as decision knowledge to "other" and property "relevant" to false (R4)', async () => {
-    const issue = await createJiraIssue('Task', 'Enhance user experience');
+    const issue = await createJiraIssue(defaultIssueType, 'Enhance user experience');
     await jira.addComment(
       issue.id,
       "I don't think we should use cookies to track our users.\n{issue}How can we enhance user experience without compromising privacy?{issue}"
@@ -226,7 +228,7 @@ describe('TCS: Test manually classify text as decision knowledge', () => {
    * Postcondition system: The comment no longer contains the macro tags but still contains the original text. The knowledge element from the comment has type "Other".
    */
   it('should remove macro tags from a manually annotated Jira comment when it is marked as irrelevant in a view on the knowledge graph (R5)', async () => {
-    const jiraIssue = await createJiraIssue('Task', 'Implement dark mode');
+    const jiraIssue = await createJiraIssue(defaultIssueType, 'Implement dark mode');
     const decisionKnowledgeElement = await createDecisionKnowledgeElement(
       'Should the default text be green?',
       'Issue',


### PR DESCRIPTION
Add a parameter `defaultIssueType` to `config.json` in order to allow users running Jira in different languages to execute the tests. This parameter can be set to "Aufgabe" if running Jira with German issue type names.